### PR TITLE
Rename tap from homebrew-brew to homebrew-wikiget

### DIFF
--- a/Formula/wikiget.rb
+++ b/Formula/wikiget.rb
@@ -8,8 +8,8 @@ class Wikiget < Formula
   license "GPL-3.0-or-later"
   head "https://github.com/clpo13/wikiget.git", branch: "master"
 
-  depends_on "clpo13/brew/mwclient"
-  depends_on "clpo13/brew/tqdm"
+  depends_on "clpo13/wikiget/mwclient"
+  depends_on "clpo13/wikiget/tqdm"
   depends_on "python@3.12"
 
   def install

--- a/README.md
+++ b/README.md
@@ -1,23 +1,27 @@
-# Homebrew
+# clpo13/homebrew-wikiget
 
-Homebrew formulae for utilities by [clpo13](https://github.com/clpo13).
+Homebrew formulae for wikiget and its dependencies.
 
 ## Included formulae
 
-* [wikiget](https://github.com/clpo13/wikiget)
+* [wikiget](https://github.com/clpo13/wikiget) v0.8.0
+  * [mwclient](https://github.com/mwclient/mwclient), v0.10.1
+  * [tqdm](https://tqdm.github.io/), v4.66.1
 
-## How do I install these formulae?
+## How do I install it?
 
-`brew install clpo13/brew/<formula>`
+`brew install clpo13/wikiget/wikiget`
 
-Or `brew tap clpo13/brew` and then `brew install <formula>`.
+Or `brew tap clpo13/wikiget` and then `brew install wikiget`.
 
-Or install via URL (which will not receive updates):
+Or install via URL (which will not receive automatic updates):
 
+```shell
+brew install https://raw.githubusercontent.com/clpo13/homebrew-wikiget/master/Formula/wikiget.rb
 ```
-brew install https://raw.githubusercontent.com/clpo13/homebrew-brew/master/Formula/<formula>.rb
-```
+
+The necessary dependencies will be pulled in automatically.
 
 ## Documentation
 
-`brew help`, `man brew` or check [Homebrew's documentation](https://docs.brew.sh).
+`brew help`, `man brew`, or check [Homebrew's documentation](https://docs.brew.sh).

--- a/README.md
+++ b/README.md
@@ -1,27 +1,28 @@
 # clpo13/homebrew-wikiget
 
-Homebrew formulae for wikiget and its dependencies.
+[Homebrew](https://brew.sh) formulae for [wikiget](https://github.com/clpo13/wikiget) and its dependencies.
 
 ## Included formulae
 
 * [wikiget](https://github.com/clpo13/wikiget) v0.8.0
-  * [mwclient](https://github.com/mwclient/mwclient), v0.10.1
-  * [tqdm](https://tqdm.github.io/), v4.66.1
+  * [mwclient](https://github.com/mwclient/mwclient) v0.10.1
+  * [tqdm](https://tqdm.github.io/) v4.66.1
 
 ## How do I install it?
 
-`brew install clpo13/wikiget/wikiget`
-
-Or `brew tap clpo13/wikiget` and then `brew install wikiget`.
-
-Or install via URL (which will not receive automatic updates):
-
 ```shell
-brew install https://raw.githubusercontent.com/clpo13/homebrew-wikiget/master/Formula/wikiget.rb
+brew install clpo13/wikiget/wikiget
 ```
 
-The necessary dependencies will be pulled in automatically.
+This repo will be tapped and the necessary dependencies will be pulled in automatically.
+
+## How do I uninstall it?
+
+```shell
+brew uninstall wikiget mwclient tqdm
+brew untap clpo13/wikiget
+```
 
 ## Documentation
 
-`brew help`, `man brew`, or check [Homebrew's documentation](https://docs.brew.sh).
+For more info, see `brew help`, `man brew`, or [Homebrew's documentation](https://docs.brew.sh).


### PR DESCRIPTION
Additionally, update the README with links and uninstallation instructions.