### PR TITLE
Add formulae removed from homebrew-core

### DIFF
--- a/Formula/python-oauthlib.rb
+++ b/Formula/python-oauthlib.rb
@@ -1,0 +1,29 @@
+class PythonOauthlib < Formula
+  desc "Python Framework for OAuth1 & OAuth2"
+  homepage "https://oauthlib.readthedocs.io/en/latest/"
+  url "https://files.pythonhosted.org/packages/6d/fa/fbf4001037904031639e6bfbfc02badfc7e12f137a8afa254df6c4c8a670/oauthlib-3.2.2.tar.gz"
+  sha256 "9859c40929662bec5d64f34d01c99e093149682a3f38915dc0655d5a633dd918"
+  license "BSD-3-Clause"
+
+  depends_on "python-setuptools" => :build
+  depends_on "python@3.11" => [:build, :test]
+  depends_on "python@3.12" => [:build, :test]
+
+  def pythons
+    deps.map(&:to_formula).sort_by(&:version).filter { |f| f.name.start_with?("python@") }
+  end
+
+  def install
+    pythons.each do |python|
+      python_exe = python.opt_libexec/"bin/python"
+      system python_exe, "-m", "pip", "install", *std_pip_args, "."
+    end
+  end
+
+  test do
+    pythons.each do |python|
+      python_exe = python.opt_libexec/"bin/python"
+      system python_exe, "-c", "from oauthlib import oauth1, oauth2"
+    end
+  end
+end

--- a/Formula/python-requests-oauthlib.rb
+++ b/Formula/python-requests-oauthlib.rb
@@ -1,0 +1,31 @@
+class PythonRequestsOauthlib < Formula
+  desc "OAuthlib support for python-requests"
+  homepage "https://requests-oauthlib.readthedocs.io/en/latest/"
+  url "https://files.pythonhosted.org/packages/95/52/531ef197b426646f26b53815a7d2a67cb7a331ef098bb276db26a68ac49f/requests-oauthlib-1.3.1.tar.gz"
+  sha256 "75beac4a47881eeb94d5ea5d6ad31ef88856affe2332b9aafb52c6452ccf0d7a"
+  license "ISC"
+
+  depends_on "python-setuptools" => :build
+  depends_on "python@3.11" => [:build, :test]
+  depends_on "python@3.12" => [:build, :test]
+  depends_on "python-oauthlib"
+  depends_on "python-requests"
+
+  def pythons
+    deps.map(&:to_formula).sort_by(&:version).filter { |f| f.name.start_with?("python@") }
+  end
+
+  def install
+    pythons.each do |python|
+      python_exe = python.opt_libexec/"bin/python"
+      system python_exe, "-m", "pip", "install", *std_pip_args, "."
+    end
+  end
+
+  test do
+    pythons.each do |python|
+      python_exe = python.opt_libexec/"bin/python"
+      system python_exe, "-c", "from requests_oauthlib import OAuth1Session"
+    end
+  end
+end


### PR DESCRIPTION
These and most other python-* formulae are being removed from homebrew-core. See homebrew/homebrew-core#157500 for rationale.